### PR TITLE
Modifications to KibanaConfig.rb file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.1.4:
 
+* Fixed permissions for KibanaConfig.rb so that the kibana user can read it.
+  Used to be root:root, now uses the :user and :group attributes (nschelly)
+
 ## v0.1.2:
 
 * Prefer new notification syntax.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,6 +53,8 @@ end
 
 template "#{node['kibana']['base_dir']}/KibanaConfig.rb" do
   source 'KibanaConfig.rb.erb'
+  user node['kibana']['user']
+  group node['kibana']['group']
   mode '0600'
   notifies :restart, 'service[kibana]', :delayed
 end


### PR DESCRIPTION
Prior to my modification, the default recipe was creating it as a root:root file with 0600 privileges.  Then, the kibana user was unable to open it to start the server.  Now, it's created using the values from node['kibana']['user'] and node['kibana']['group'] instead.
-Neil
