### PR TITLE
add default_fields attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,28 @@ Kibana requires ElasticSearch index to be configured to work as per logstash req
 Attributes
 ==========
 
+### Install Options ###
+
 * `node['kibana']['base_dir']` - The base directory of kibana. Defaults to '/opt/kibana'.
 * `node['kibana']['user']` - The user under which Kibana is installed. Defaults to 'kibana'.
 * `node['kibana']['group']` - The group under which Kibana is installed. Defaults to 'kibana'.
 * `node['kibana']['git']['url']` - The URL to Kibana repository. Defaults to 'git://github.com/rashidkpc/Kibana.git'.
 * `node['kibana']['git']['reference']` - The git reference in the Kibana repository. Defaults to 'v0.2.0'.
+* `node['kibana']['rubyversion']` - The version of Ruby and Gems to use for Kibana.Defaults to `1.9.1`
+
+### KibanaConfig Options ###
+
 * `node['kibana']['interface']` - The interface on which to bind. Defaults to node['ipaddress'].
 * `node['kibana']['port']` - The port on which to bind. Defaults to 5601.
 * `node['kibana']['elasticsearch']['hosts']` - An Array of the elasticsearch service hosts. Defaults to ['127.0.0.1'].
 * `node['kibana']['elasticsearch']['port']` - The port of the elasticsearch http service. Defaults to 9200.
+* `node['kibana']['default_fields']` - The which fields are shown by default. Defaults to `["@message"]`.
+
+### Apache Config Options ###
+
 * `node['kibana']['apache']['host']` - The host to create apache vhost for. Defaults to `node['fqdn']`
 * `node['kibana']['apache']['interface']` - The interface on which to bind apache. Defaults to `node['ipaddress']`
 * `node['kibana']['apache']['port']` - The port on which to bind apache. Defaults to 80.
-* `node['kibana']['rubyversion']` - The version of Ruby and Gems to use for Kibana.Defaults to `1.9.1`
 
 
 Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['kibana']['interface'] = node['ipaddress']
 default['kibana']['port'] = 5601
 default['kibana']['elasticsearch']['hosts'] = ['127.0.0.1']
 default['kibana']['elasticsearch']['port'] = 9200
+default['kibana']['default_fields'] = '["@message"]'
 
 #Apache Config Options
 default['kibana']['apache']['host'] = node['fqdn']

--- a/templates/default/KibanaConfig.rb.erb
+++ b/templates/default/KibanaConfig.rb.erb
@@ -49,7 +49,7 @@ module KibanaConfig
 
   # Change which fields are shown by default. Must be set as an array
   # Default_fields = ['@fields.vhost','@fields.response','@fields.request']
-  Default_fields = ['@message']
+  Default_fields = <%= node['kibana']['default_fields'] %>
 
   # If set to true, Kibana will use the Highlight feature of Elasticsearch to
   # display highlighted search results


### PR DESCRIPTION
Allows configuring the `Default_fields` of the `KibanaConfig.rb`, defaulting to the current value of `["@message"]`.
