### PR TITLE
add default_operator attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Attributes
 * `node['kibana']['port']` - The port on which to bind. Defaults to 5601.
 * `node['kibana']['elasticsearch']['hosts']` - An Array of the elasticsearch service hosts. Defaults to ['127.0.0.1'].
 * `node['kibana']['elasticsearch']['port']` - The port of the elasticsearch http service. Defaults to 9200.
+* `node['kibana']['default_operator']` - The operator used if no explicit operator is specified. Defaults to `"NO"`.
 * `node['kibana']['apache']['host']` - The host to create apache vhost for. Defaults to `node['fqdn']`
 * `node['kibana']['apache']['interface']` - The interface on which to bind apache. Defaults to `node['ipaddress']`
 * `node['kibana']['apache']['port']` - The port on which to bind apache. Defaults to 80.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['kibana']['interface'] = node['ipaddress']
 default['kibana']['port'] = 5601
 default['kibana']['elasticsearch']['hosts'] = ['127.0.0.1']
 default['kibana']['elasticsearch']['port'] = 9200
+default['kibana']['default_operator'] = 'OR'
 
 #Apache Config Options
 default['kibana']['apache']['host'] = node['fqdn']

--- a/templates/default/KibanaConfig.rb.erb
+++ b/templates/default/KibanaConfig.rb.erb
@@ -68,7 +68,7 @@ module KibanaConfig
   # Hungary is translated to capital OR of OR Hungary, and with default
   # operator of AND, the same query is translated to capital AND of AND
   # Hungary. The default value is OR.
-  Default_operator = 'OR'
+  Default_operator = '<%= node['kibana']['default_operator'] %>'
 
   # When using analyze, use this many of the most recent
   # results for user's query


### PR DESCRIPTION
Allows configuring the `Default_operator` of the `KibanaConfig.rb`, defaulting to the current value of `"NO"`.
