### PR TITLE
Fix proxy configuration for nginx

### DIFF
--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -18,7 +18,7 @@ function (Settings) {
      * elasticsearch host
      * @type {String}
      */
-    <% if node['kibana']['apache']['proxy'] %>
+    <% if node['kibana']['apache']['proxy'] or node['kibana']['nginx']['proxy'] %>
     elasticsearch: window.location.protocol + "//" + window.location.hostname,
     <% else %>
     elasticsearch: "http://" + window.location.hostname + ":<%= @es_port %>",


### PR DESCRIPTION
Without this check the only method to get running proxy configuration in nginx is setting node['kibana']['apache']['proxy'] to true :-)