### PR TITLE
Correct vhost configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.10:
 * Support proxying elasticsearch through apache. Submitted by Dmitry (cyberflow).
 * Replace depends with suggest for the apache cookbook as it is not needed when using nginx. Submitted by Bryan Casey.
+* Correct apache configuration to work with apache < 2.4. Submitted by Olivier Dolbeau (odolbeau).
 
 ## v0.1.8:
 * nginx support. Submitted by Gregoire Seux and Jonathon W. Marshall.

--- a/templates/default/vhost3.conf.erb
+++ b/templates/default/vhost3.conf.erb
@@ -47,9 +47,12 @@ NameVirtualHost <%= node['kibana']['apache']['interface'] %>:<%= node['kibana'][
   <% else %>
 
     <Location "/">
-      Order allow,deny
-      Allow from all
-      Require all granted
+      <% if node['apache']['version'] == '2.4' %>
+        Require all granted
+      <% else %>
+        Order allow,deny
+        Allow from all
+      <% end %>
       SetHandler None
     </Location>
 


### PR DESCRIPTION
As described [here](http://httpd.apache.org/docs/2.4/en/upgrading.html), `Require all granted` is the equivalent in apache 2.4 of `Order allow,deny + Allow from all` in 2.2.