### PR TITLE
Kibana cookbook is still compatible with apache2 cookbook 1.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version '0.1.9'
 
 depends 'build-essential'
 depends 'ark'
-suggests 'apache2', '>= 2.0'
+suggests 'apache2'
 suggests 'authbind'
 suggests 'apt'
 suggests 'nginx'


### PR DESCRIPTION
Removes an unnecessary constraint introduced in 9057bf1 #24 which asserts a
dependency apache2 >= 2.0.0, but in fact this cookbook converges just fine
with apache2 >= 1.0.0 (tested with 1.4.2).

The real danger is that somebody upgrades their apache2 cookbook to 2.0.0
while still using kibana == 0.1.7, and Apache will fail to load the site
configuration files. There's nothing you can do to stop that.