### PR TITLE
config: unify kibana3 and kibana4 url

### DIFF
--- a/recipes/kibana3.rb
+++ b/recipes/kibana3.rb
@@ -31,5 +31,9 @@ template File.join(node['kibana']['base_dir'], config_path) do
   owner node['kibana']['user']
   group node['kibana']['group']
   mode '0644'
-  variables('es_port' => node['kibana']['elasticsearch']['port'], 'index' => node['kibana']['index'])
+  variables(
+    'es_host' => node['kibana']['elasticsearch']['hosts'].first,
+    'es_port' => node['kibana']['elasticsearch']['port'],
+    'index'   => node['kibana']['index']
+  )
 end

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -9,19 +9,13 @@ function (Settings) {
   return new Settings({
 
     /**
-     * URL to your elasticsearch server. You almost certainly don't
-     * want 'http://localhost:9200' here. Even if Kibana and ES are on
-     * the same host
-     *
-     * By default this will attempt to reach ES at the same host you have
-     * elasticsearch installed on. You probably want to set it to the FQDN of your
-     * elasticsearch host
+     * The Elasticsearch instance to use for all your queries
      * @type {String}
      */
-    <% if node['kibana']['apache']['proxy'] or node['kibana']['nginx']['proxy'] %>
-    elasticsearch: window.location.protocol + "//" + window.location.hostname,
-    <% else %>
+    <% if ['127.0.0.1', '0.0.0.0'].include? node['kibana']['elasticsearch']['hosts'].first %>
     elasticsearch: "http://" + window.location.hostname + ":<%= @es_port %>",
+    <% else %>
+    elasticsearch: "http://<%= @es_host %>:<%= @es_port %>",
     <% end %>
 
     /**


### PR DESCRIPTION
use the same system to templatise the ES url for both kibana3 and
kibana4
