### PR TITLE
Fix service file permissions.

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -3,7 +3,7 @@
 template node['kibana']['service']['template_file'] do
   cookbook node['kibana']['service']['cookbook']
   source node['kibana']['service']['source']
-  mode '0755'
+  mode '0o0755'
   variables(
     version: node['kibana']['version'],
     options: '', # TODO

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -3,6 +3,7 @@
 template node['kibana']['service']['template_file'] do
   cookbook node['kibana']['service']['cookbook']
   source node['kibana']['service']['source']
+  mode '0755'
   variables(
     version: node['kibana']['version'],
     options: '', # TODO


### PR DESCRIPTION
According to 'resource_template' Chef docs, default 'mode' property value is '0777' minus umask. In order to prevent undefined behavior for file permissions, as umask can vary for different systems, static value should be set up.