### PR TITLE
Add logging options for Kibana 4.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -158,3 +158,12 @@ default['kibana']['service']['cookbook'] = 'kibana'
 
 #<> The kibana 4 default application on load
 default['kibana']['defaultapp'] = 'discover'
+
+# Logging options. Logs to stdout by default.
+default['kibana']['log_to_file'] = 'false'
+default['kibana']['logfile'] = "#{node['kibana']['base_dir']}/kibana.log"
+default['kibana']['logging_option'] = ''
+
+if node['kibana']['log_to_file'] == 'true'
+  default['kibana']['logging_option'] = "log_file: #{node['kibana']['logfile']}"
+end

--- a/recipes/kibana4.rb
+++ b/recipes/kibana4.rb
@@ -24,12 +24,13 @@ template File.join(node['kibana']['base_dir'], config_path) do
   group node['kibana']['group']
   mode '0644'
   variables(
-    bind:       node['kibana']['interface'],
-    port:       node['kibana']['port'],
-    es_host:    node['kibana']['elasticsearch']['hosts'].first,
-    es_port:    node['kibana']['elasticsearch']['port'],
-    index:      node['kibana']['index'],
-    defaultapp: node['kibana']['defaultapp']
+    bind:           node['kibana']['interface'],
+    port:           node['kibana']['port'],
+    es_host:        node['kibana']['elasticsearch']['hosts'].first,
+    es_port:        node['kibana']['elasticsearch']['port'],
+    index:          node['kibana']['index'],
+    defaultapp:     node['kibana']['defaultapp'],
+    logging_option: node['kibana']['logging_option']
   )
   notifies :restart, 'service[kibana]'
 end

--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -66,7 +66,7 @@ verify_ssl: true
 # If you would like to send the log output to a file you can set the path below.
 # This will also turn off the STDOUT log output.
 # log_file: ./kibana.log
-<%= @logging_option %>
+<%= @logging_option -%>
 
 # Plugins that are included in the build, and no longer found in the plugins/ folder
 bundled_plugin_ids:

--- a/templates/default/kibana.yml.erb
+++ b/templates/default/kibana.yml.erb
@@ -66,6 +66,7 @@ verify_ssl: true
 # If you would like to send the log output to a file you can set the path below.
 # This will also turn off the STDOUT log output.
 # log_file: ./kibana.log
+<%= @logging_option %>
 
 # Plugins that are included in the build, and no longer found in the plugins/ folder
 bundled_plugin_ids:


### PR DESCRIPTION
Logs are lost if Kibana is running as a service, since it logs to stdout by default. This commit enables possibility of turning on file logging.