### PR TITLE
chefspec platform updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   - TESTS="integration:docker[kibana4-apache-centos-72]"
   - TESTS="integration:docker[kibana4-nginx-centos-72]"
 
-before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk -v 0.15.16
+before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk
 install: chef exec bundle install --jobs=3 --retry=3 --without='vagrant'
 
 # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888

--- a/test/unit/spec/_service_spec.rb
+++ b/test/unit/spec/_service_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 # for ubuntu 14.04 upstart
 describe 'kibana::_service' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new((UBUNTU_OPTS)).converge(described_recipe) }
   let(:template) { chef_run.template('/etc/init/kibana.conf') }
   it 'creates an upstart template at /etc/init/kibana.conf' do
     expect(chef_run).to create_template('/etc/init/kibana.conf')
@@ -20,7 +20,7 @@ end
 # for ubuntu 16.04 systemd
 describe 'kibana::_service' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_1604_OPTS).converge(described_recipe) }
   let(:template) { chef_run.template('/lib/systemd/system/kibana.service') }
   it 'creates an upstart template at /lib/systemd/system/kibana.service' do
     expect(chef_run).to create_template('/lib/systemd/system/kibana.service')
@@ -36,7 +36,7 @@ end
 # for centos 6.x init
 describe 'kibana::_service' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '6.0').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(CENTOS_OPTS).converge(described_recipe) }
   let(:template) { chef_run.template('/etc/init.d/kibana') }
 
   it 'creates an init.d template at /etc/init.d/kibana' do
@@ -53,7 +53,7 @@ end
 # for centos 7.x systemd
 describe 'kibana::_service' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(CENTOS7_OPTS).converge(described_recipe) }
   let(:template) { chef_run.template('/usr/lib/systemd/system/kibana.service') }
   it 'creates an init.d template at /usr/lib/systemd/system/kibana.service' do
     expect(chef_run).to create_template('/usr/lib/systemd/system/kibana.service')

--- a/test/unit/spec/_service_spec.rb
+++ b/test/unit/spec/_service_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 # for ubuntu 14.04 upstart
 describe 'kibana::_service' do
   before { stub_resources }
-  let(:chef_run) { ChefSpec::SoloRunner.new((UBUNTU_OPTS)).converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_OPTS).converge(described_recipe) }
   let(:template) { chef_run.template('/etc/init/kibana.conf') }
   it 'creates an upstart template at /etc/init/kibana.conf' do
     expect(chef_run).to create_template('/etc/init/kibana.conf')

--- a/test/unit/spec/apache_spec.rb
+++ b/test/unit/spec/apache_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'kibana::apache' do
   before { stub_resources }
 
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_OPTS).converge(described_recipe) }
 
   # TODO: creates a template /etc/apache2/htpasswd
   # TODO: creates a template /etc/apache2/sites-available/kibana.conf

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'kibana::default' do
   before { stub_resources }
 
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_OPTS).converge(described_recipe) }
 
   it 'creates kibana group' do
     expect(chef_run).to create_group('kibana')

--- a/test/unit/spec/kibana3_spec.rb
+++ b/test/unit/spec/kibana3_spec.rb
@@ -4,7 +4,7 @@ require_relative 'spec_helper'
 describe 'kibana::kibana3' do
   before { stub_resources }
 
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_OPTS).converge(described_recipe) }
 
   it 'includes kibana recipe' do
     expect(chef_run).to include_recipe('kibana::default')
@@ -28,7 +28,7 @@ describe 'kibana::kibana3' do
   before { stub_resources }
 
   let(:chef_run) do
-    ChefSpec::SoloRunner.new do |node|
+    ChefSpec::SoloRunner.new(UBUNTU_OPTS) do |node|
       node.override['kibana']['install_method'] = 'source'
     end.converge(described_recipe)
   end

--- a/test/unit/spec/kibana4_spec.rb
+++ b/test/unit/spec/kibana4_spec.rb
@@ -5,7 +5,7 @@ describe 'kibana::kibana4' do
   before { stub_resources }
 
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '14.04') do |node|
+    ChefSpec::SoloRunner.new(UBUNTU_OPTS) do |node|
       node.default['kibana']['install_method'] = 'release'
     end.converge(described_recipe, 'kibana::_service')
   end

--- a/test/unit/spec/nginx_spec.rb
+++ b/test/unit/spec/nginx_spec.rb
@@ -4,5 +4,5 @@ require_relative 'spec_helper'
 describe 'kibana::nginx' do
   before { stub_resources }
 
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(UBUNTU_OPTS).converge(described_recipe) }
 end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -14,6 +14,18 @@ require 'support/matchers'
   platform: 'ubuntu',
   version: '14.04'
 }.freeze
+::UBUNTU_1604_OPTS = {
+  platform: 'ubuntu',
+  version: '16.04'
+}.freeze
+::CENTOS_OPTS = {
+  platform: 'centos',
+  version: '6.0'
+}.freeze
+::CENTOS7_OPTS = {
+  platform: 'centos',
+  version: '7.0'
+}.freeze
 
 def stub_resources
 end


### PR DESCRIPTION
This adds some basic variables for the changes in how ChefSpec requires platform name/version in SoloRunner.  

Removes the version pin on the chefdk install in travis setup.