### PR TITLE
Switch to chef_nginx cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,7 +38,7 @@ suites:
 - name: kibana3_nginx
   run_list:
     - 'recipe[netstat]'
-    - 'recipe[nginx]'
+    - 'recipe[chef_nginx]'
     - 'recipe[kibana]'
     - 'recipe[kibana::nginx]'
   attributes: {}
@@ -73,7 +73,7 @@ suites:
 - name: kibana4_nginx
   run_list:
     - 'recipe[netstat]'
-    - 'recipe[nginx]'
+    - 'recipe[chef_nginx]'
     - 'recipe[java]'
     - 'recipe[elasticsearch]'
     - 'recipe[kibana]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   - TESTS="integration:docker[kibana4-apache-centos-72]"
   - TESTS="integration:docker[kibana4-nginx-centos-72]"
 
-before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk -v 0.15.16
+before_install: curl -L https://www.getchef.com/chef/install.sh | sudo bash -s -- -P chefdk
 install: chef exec bundle install --jobs=3 --retry=3 --without='vagrant'
 
 # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888

--- a/Berksfile
+++ b/Berksfile
@@ -9,5 +9,5 @@ group :vagrant do
     cookbook 'java'
     cookbook 'ohai'
     cookbook 'netstat'
-    cookbook 'nginx', '~ 2.7.6'
+    cookbook 'chef_nginx', '~ 2.9.0'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,6 +20,6 @@ depends 'apt'
 # Suggests is not officially valid, that is why these are commented out
 # suggests 'apache2', '>= 2.0'
 # suggests 'authbind'
-# suggests 'nginx'
+# suggests 'chef_nginx'
 # suggests 'java'
 # suggests 'elasticsearch'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 
-include_recipe 'nginx'
+include_recipe 'chef_nginx'
 
 template File.join(node['nginx']['dir'], 'sites-available', 'kibana') do
   source node['kibana']['version'] == '4' ? 'nginx4.conf.erb' : 'nginx.conf.erb'


### PR DESCRIPTION
Chef took over the nginx cookbook and renamed it chef_nginx.  This PR should switch to using the chef_nginx cookbook which appears to have more active development, while being compatible with our usage as is.