### PR TITLE
update nginx source attribute

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ AllCops:
 
 BlockComments:
   Enabled: false
+BlockLength:
+  Enabled: false
 
 LeadingCommentSpace:
   Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,6 +126,7 @@ default['kibana']['nginx']['ssl_session_timeout'] = '10m'
 default['kibana']['nginx']['server_name'] = 'kibana'
 
 #<> The nginx configuration source
+default['kibana']['nginx']['source'] = node['kibana']['version'] == '4' ? 'nginx4.conf.erb' : 'nginx.conf.erb' 
 default['kibana']['nginx']['cookbook'] = 'kibana'
 
 #<> Redirect requests to kibana service

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,7 +126,7 @@ default['kibana']['nginx']['ssl_session_timeout'] = '10m'
 default['kibana']['nginx']['server_name'] = 'kibana'
 
 #<> The nginx configuration source
-default['kibana']['nginx']['source'] = node['kibana']['version'] == '4' ? 'nginx4.conf.erb' : 'nginx.conf.erb' 
+default['kibana']['nginx']['source'] = node['kibana']['version'] == '4' ? 'nginx4.conf.erb' : 'nginx.conf.erb'
 default['kibana']['nginx']['cookbook'] = 'kibana'
 
 #<> Redirect requests to kibana service

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -3,7 +3,7 @@
 include_recipe 'chef_nginx'
 
 template File.join(node['nginx']['dir'], 'sites-available', 'kibana') do
-  source node['kibana']['version'] == '4' ? 'nginx4.conf.erb' : 'nginx.conf.erb'
+  source node['kibana']['nginx']['source']
   cookbook node['kibana']['nginx']['cookbook']
   owner node['nginx']['user']
   mode '0644'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,5 +1,4 @@
 # Encoding: utf-8
-
 include_recipe 'chef_nginx'
 
 template File.join(node['nginx']['dir'], 'sites-available', 'kibana') do

--- a/test/integration/kibana4_apache/serverspec/default_spec.rb
+++ b/test/integration/kibana4_apache/serverspec/default_spec.rb
@@ -13,7 +13,7 @@ describe 'kibana' do
 end
 
 describe 'apache' do
-  describe port(80) do
+  describe port(8080) do
     it { should be_listening }
   end
   describe service('apache2'), if: os[:family] == 'ubuntu' do

--- a/test/integration/kibana4_apache/serverspec/default_spec.rb
+++ b/test/integration/kibana4_apache/serverspec/default_spec.rb
@@ -13,7 +13,7 @@ describe 'kibana' do
 end
 
 describe 'apache' do
-  describe port(8080) do
+  describe port(80) do
     it { should be_listening }
   end
   describe service('apache2'), if: os[:family] == 'ubuntu' do

--- a/test/integration/kibana4_nginx/serverspec/default_spec.rb
+++ b/test/integration/kibana4_nginx/serverspec/default_spec.rb
@@ -13,7 +13,7 @@ describe 'kibana' do
 end
 
 describe 'nginx' do
-  describe port(8080) do
+  describe port(80) do
     it { should be_listening }
   end
   describe service('nginx') do


### PR DESCRIPTION
This is to cleanup the kibana.nginx.source attribute in the recipe.  Hoping to make it easier to read how to override that attribute to name a different place to put the erb template in a local wrapper cookbook or role/node file.

This includes a couple of rubocop touch ups and changing the port for nginx to 80 in the integration tests (wasn't working locally in vagrant which was doing a vagrant port forward).