### PR TITLE
set bin_path for package installs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -102,5 +102,21 @@ suites:
         port: 8080
       interface: '0.0.0.0'
       service:
-        bin_path: 'bin'
         options: '--max-old-space-size=100'
+- name: kibana4_nginx_package
+  run_list:
+    - 'recipe[netstat]'
+    - 'recipe[chef_nginx]'
+    - 'recipe[java]'
+    - 'recipe[elasticsearch]'
+    - 'recipe[kibana]'
+    - 'recipe[kibana::nginx]'
+  attributes:
+    kibana:
+      install_method: 'package'
+      version: '4'
+      interface: '0.0.0.0'
+      nginx:
+        listen_http: 8080
+    java:
+      jdk_version: '8'

--- a/recipes/kibana4.rb
+++ b/recipes/kibana4.rb
@@ -13,6 +13,7 @@ if node['kibana']['install_method'] == 'release'
   end
   config_path = 'current/config/kibana.yml'
 elsif node['kibana']['install_method'] == 'package'
+  node.default['kibana']['service']['bin_path'] = 'bin'
   if node.platform_family? 'debian'
     apt_repository 'kibana' do
       uri node['kibana']['repository_url']


### PR DESCRIPTION
bin_path was incorrectly set to current/bin on a package install (where it should be bin).  We already have a section this so add a node.default into the recipe to set this attribute when package is chosen as the install type.

This adds a kitchen test suite so that locally someone can run kitchen tests on an nginx4_package install across the platforms.
