### PR TITLE
Update to fix travis runs for CentOS7 and Ubuntu 16.04.

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -2,3 +2,15 @@
 driver:
   name: docker
   privileged: true
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+    driver_config:
+      run_command: /sbin/init
+  - name: centos-6.4
+  - name: centos-7.2
+    driver_config:
+      image: centos:7
+      provision_command: yum -y install initscripts
+      run_command: /usr/sbin/init

--- a/Berksfile
+++ b/Berksfile
@@ -3,9 +3,10 @@ source 'https://supermarket.chef.io/'
 metadata
 
 group :vagrant do
+    cookbook 'ark', '= 2.1.0'
     cookbook 'apt'
     cookbook 'apache2'
-    cookbook 'elasticsearch'
+    cookbook 'elasticsearch', '~ 2.4.0'
     cookbook 'java'
     cookbook 'ohai'
     cookbook 'netstat'


### PR DESCRIPTION
Pin ark for travis testing due to bug in ark 2.2.0
Pin elasticsearch at 2.4.0 for testing pre ES-5.0