### PR TITLE
Upstream fixed an issue, try the 2.2.1 ark release

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ source 'https://supermarket.chef.io/'
 metadata
 
 group :vagrant do
-    cookbook 'ark', '= 2.1.0'
+    cookbook 'ark', '= 2.2.1'
     cookbook 'apt'
     cookbook 'apache2'
     cookbook 'elasticsearch', '~ 2.4.0'


### PR DESCRIPTION
Tests pass with new version of the upstream ark cookbook.