### PR TITLE
attributes: switch ['kibana']['version'] to integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Kibana requires ElasticSearch index to be configured to work as per logstash req
 
 # Attributes
 
-* `node['kibana']['version']` - Kibana version. Defaults to `5`.
+* `node['kibana']['version']` - Kibana major version used. Defaults to `5`.
 * `node['kibana']['kibana3_version']` - Kibana3 exact version.
 * `node['kibana']['kibana4_version']` - Kibana4 exact version.
 * `node['kibana']['kibana5_version']` - Kibana5 exact version.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 # Encoding: utf-8
 
 #<> Kibana major version
-default['kibana']['version'] = '5'
+default['kibana']['version'] = 5
 
 #<> Kibana3 exact version
 default['kibana']['kibana3_version'] = '3.1.2'
@@ -54,7 +54,7 @@ default['kibana']['elasticsearch']['hosts'] = ['127.0.0.1']
 #<> The port of the elasticsearch http service.
 default['kibana']['elasticsearch']['port'] = 9200
 
-default['kibana']['index'] = if node['kibana']['version'] > '3'
+default['kibana']['index'] = if node['kibana']['version'] > 3
                                '.kibana'
                              else
                                'kibana-int'
@@ -129,12 +129,12 @@ default['kibana']['nginx']['ssl_session_timeout'] = '10m'
 default['kibana']['nginx']['server_name'] = 'kibana'
 
 #<> The nginx configuration source
-default['kibana']['nginx']['source'] = node['kibana']['version'] == '4' ? 'nginx4.conf.erb' : 'nginx.conf.erb'
+default['kibana']['nginx']['source'] = node['kibana']['version'] == 4 ? 'nginx4.conf.erb' : 'nginx.conf.erb'
 default['kibana']['nginx']['cookbook'] = 'kibana'
 
 #<> Redirect requests to kibana service
 default['kibana']['kibana_service'] = nil
-unless node['kibana']['version'] =~ /^3/
+unless node['kibana']['version'] == 3
   default['kibana']['kibana_service'] = "http://#{node['kibana']['interface']}:#{node['kibana']['port']}"
 end
 
@@ -178,9 +178,9 @@ default['kibana']['logfile'] = "#{node['kibana']['base_dir']}/kibana.log"
 default['kibana']['logging_option'] = ''
 
 if node['kibana']['log_to_file']
-  if node['kibana']['version'] == '3' ||  node['kibana']['version'] == '4'
+  if node['kibana']['version'] <= 4
     default['kibana']['logging_option'] = "log_file: #{node['kibana']['logfile']}"
-  elsif node['kibana']['version'] == '5'
+  elsif node['kibana']['version'] >= 5
     default['kibana']['logging_option'] = "logging.dest: #{node['kibana']['logfile']}"
   end
 end

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -25,8 +25,8 @@ template "#{node['apache']['dir']}/sites-available/kibana.conf" do
     'kibana_service' => node['kibana']['kibana_service'],
     'port' => node['kibana']['elasticsearch']['port']
   )
-  source 'vhost3.conf.erb' if node['kibana']['version'] =~ /^3/
-  source 'vhost4.conf.erb' if node['kibana']['version'] =~ /^4/
+  source 'vhost3.conf.erb' if node['kibana']['version'] == 3
+  source 'vhost4.conf.erb' if node['kibana']['version'] == 4
   cookbook node['kibana']['apache']['cookbook']
   owner node['apache']['user']
   group node['apache']['group']

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -26,7 +26,7 @@ template "#{node['apache']['dir']}/sites-available/kibana.conf" do
     'port' => node['kibana']['elasticsearch']['port']
   )
   source 'vhost3.conf.erb' if node['kibana']['version'] == 3
-  source 'vhost4.conf.erb' if node['kibana']['version'] == 4
+  source 'vhost4.conf.erb' if node['kibana']['version'] >= 4
   cookbook node['kibana']['apache']['cookbook']
   owner node['apache']['user']
   group node['apache']['group']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,4 +24,4 @@ directory node['kibana']['base_dir'] do
   recursive true
 end
 
-include_recipe "kibana::kibana#{node['kibana']['version'][0]}"
+include_recipe "kibana::kibana#{node['kibana']['version']}"

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -16,7 +16,7 @@ load_current_value do
 end
 
 def plugin_exists?(name)
-  list_arg = node['kibana']['version'][0].to_i > 4 ? 'bin/kibana-plugin list' : 'bin/kibana plugin -l'
+  list_arg = node['kibana']['version'] > 4 ? 'bin/kibana-plugin list' : 'bin/kibana plugin -l'
   cmd_line = "#{list_arg}"
   cmd = Mixlib::ShellOut.new(cmd_line, cwd: kibana_home)
   cmd.run_command
@@ -35,7 +35,7 @@ def update_plugin_reg(action)
 end
 
 action :install do
-  install_arg = node['kibana']['version'][0].to_i > 4 ? "bin/kibana-plugin install #{url}" : "bin/kibana plugin -i #{name} -u #{url}"
+  install_arg = node['kibana']['version'] > 4 ? "bin/kibana-plugin install #{url}" : "bin/kibana plugin -i #{name} -u #{url}"
   plugin_install = "#{install_arg}"
   execute 'plugin-install' do
     cwd kibana_home
@@ -46,7 +46,7 @@ action :install do
 end
 
 action :remove do
-  remove_arg = node['kibana']['version'][0].to_i > 4 ? "bin/kibana-plugin remove #{name}" : "bin/kibana plugin --remove #{name}"
+  remove_arg = node['kibana']['version'] > 4 ? "bin/kibana-plugin remove #{name}" : "bin/kibana plugin --remove #{name}"
   plugin_remove = "#{remove_arg}"
   execute 'plugin-remove' do
     cwd kibana_home


### PR DESCRIPTION
there is no reason to keep it as string, it simplifies the needed
comparison in following code
it might however break other cookbooks using it

also support kibana5 for apache