### PR TITLE
move away from deprecated nginx fork cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,7 +5,7 @@ source 'https://supermarket.chef.io/'
 metadata
 
 group :vagrant do
-  cookbook 'ark', '>= 2.2.1'
+  cookbook 'ark'
   cookbook 'apt'
   cookbook 'apache2'
   cookbook 'build-essential'
@@ -13,5 +13,5 @@ group :vagrant do
   cookbook 'java'
   cookbook 'netstat'
   cookbook 'ohai'
-  cookbook 'chef_nginx', '~ 2.9.0'
+  cookbook 'nginx', '>= 7.0'
 end

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Kibana requires ElasticSearch index to be configured to work as per logstash req
 * apache2 (>= 2.0) (Suggested but not required)
 * authbind (Suggested but not required)
 * apt (Suggested but not required)
-* chef_nginx (Suggested but not required)
+* nginx (Suggested but not required)
 
 # Attributes
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -23,6 +23,6 @@ depends 'apt'
 # Suggests is not officially valid, that is why these are commented out
 # suggests 'apache2', '>= 2.0'
 # suggests 'authbind'
-# suggests 'chef_nginx'
+# suggests 'nginx'
 # suggests 'java'
 # suggests 'elasticsearch'

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-include_recipe 'chef_nginx'
+include_recipe 'nginx'
 
 template File.join(node['nginx']['dir'], 'sites-available', 'kibana') do
   source node['kibana']['nginx']['source']


### PR DESCRIPTION
[`chef_nginx` is now deprecated](https://supermarket.chef.io/cookbooks/chef_nginx).

This moves us to the unified, chef-owned `nginx` cookbook and relaxes version constraints to not required an anicent `ohai` version.