### PR TITLE
Test kibana5

### DIFF
--- a/test/integration/kibana5_apache/serverspec/default_spec.rb
+++ b/test/integration/kibana5_apache/serverspec/default_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'kibana' do
+  describe file('/opt/kibana') do
+    it { should be_directory }
+  end
+  describe service('kibana') do
+    it { should be_enabled }
+    # TODO: This test fails in Travis but was working with a local kitchen verify
+    #    it { should be_running }
+  end
+end
+
+describe 'apache' do
+  describe port(8080) do
+    it { should be_listening }
+  end
+  describe service('apache2'), if: os[:family] == 'ubuntu' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+  describe service('httpd'), if: os[:family] == 'redhat' do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/integration/kibana5_apache/serverspec/spec_helper.rb
+++ b/test/integration/kibana5_apache/serverspec/spec_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec

--- a/test/integration/kibana5_nginx/serverspec/default_spec.rb
+++ b/test/integration/kibana5_nginx/serverspec/default_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'kibana' do
+  describe file('/opt/kibana') do
+    it { should be_directory }
+  end
+  describe service('kibana') do
+    it { should be_enabled }
+    # TODO: This test fails in Travis but was working with a local kitchen verify
+    #    it { should be_running }
+  end
+end
+
+describe 'nginx' do
+  describe port(80) do
+    it { should be_listening }
+  end
+  describe service('nginx') do
+    it { should be_enabled }
+  end
+end

--- a/test/integration/kibana5_nginx/serverspec/spec_helper.rb
+++ b/test/integration/kibana5_nginx/serverspec/spec_helper.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec

--- a/test/unit/spec/kibana5_spec.rb
+++ b/test/unit/spec/kibana5_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+describe 'kibana::kibana5' do
+  before { stub_resources }
+  supported_platforms.each do |platform, versions|
+    versions.each do |version|
+      context "on #{platform.capitalize} #{version}" do
+        let(:chef_run) do
+          ChefSpec::ServerRunner.new(platform: platform, version: version) do |node, server|
+            node_resources(node)
+            stub_chef_zero(platform, version, server)
+            node.override['kibana']['version'] = 5
+            node.override['kibana']['install_method'] = 'release'
+          end.converge(described_recipe, 'kibana::_service')
+        end
+
+        _property = load_platform_properties(platform: platform, platform_version: version)
+
+        let(:template) { chef_run.template('/opt/kibana/current/config/kibana.yml') }
+
+        it 'includes kibana recipe' do
+          expect(chef_run).to include_recipe('kibana::default')
+        end
+        it 'includes the kibana::_service recipe' do
+          expect(chef_run).to include_recipe('kibana::_service')
+        end
+
+        it 'installs kibana4 using ark' do
+          expect(chef_run).to install_ark('kibana')
+        end
+
+        it 'creates a template for the kibana config' do
+          expect(chef_run).to create_template('/opt/kibana/current/config/kibana.yml').with(
+            owner: 'kibana',
+            group: 'kibana',
+            mode:  '0644'
+          )
+        end
+        it 'sends a restart notification to the service kibana' do
+          expect(template).to notify('service[kibana]').to(:restart)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
as we continue to refactor code (and eventually deprecate Kibana v3 support, etc) we should add basic test coverage for Kibana5.

- [x] unit tests
- [x] integration tests
- [ ] test-kitchen suite
- [ ] enabled in `.travis.yml`